### PR TITLE
Bugfix:  MIP BAB messages causing crash of tt++

### DIFF
--- a/3k/mip.tin
+++ b/3k/mip.tin
@@ -645,114 +645,114 @@
 #NOP ***** 2 Way Communication (Tell/Emote) *****
 #ALIAS {.mipProcessBABgag} {
 	#var mipgag 0;
+	#line strip #var msg %0;
 
 	#NOP Duplicate 'from' soul;
-	#REGEX {%0} {~you~} {#var mipgag 1};
-
+	#REGEX {$msg} {~you~} {#var mipgag 1};
 
 	#NOP Add cases for tells/emotes to gag from monitor, such as mob emotes;
 
 	#NOP Player specific gags;
 	#NOP Byron crying OW;
-	#REGEX {%0} {~Byron~cries 'OW!!'} {#var mipgag 1};
-	#REGEX {%0} {~%w~pokes %w in the ribs} {#var mipgag 1};
+	#REGEX {$msg} {~Byron~cries 'OW!!'} {#var mipgag 1};
+	#REGEX {$msg} {~%w~pokes %w in the ribs} {#var mipgag 1};
 
 	#NOP Guilds and Areass;
 	#NOP Bards;
-	#REGEX {%0} {~cracks %w knuckles and gets ready to play for } {#var mipgag 1};
-	#REGEX {%0} {~ceases his performance.} {#var mipgag 1};
-	#REGEX {%0} {~takes a deep breath.} {#var mipgag 1};
-	#REGEX {%0} {~takes a breath.} {#var mipgag 1};
-	#REGEX {%0} {~pauses for a moment...} {#var mipgag 1};
-	#REGEX {%0} {~ceases his performance.} {#var mipgag 1};
-	#REGEX {%0} {~%w~finishes %w performance with a bow.} {#var mipgag 1};
-	#REGEX {%0} {~%w~takes a deep breath and prepares to perform a song for you.} {#var mipgag 1};
-	#REGEX {%0} {~Great~cheer fills you, it's almost overwhelming!} {#var mipgag 1};
-	#REGEX {%0} {~%w~smiles happily.} {#var mipgag 1};
-	#REGEX {%0} {~%w~takes a deep breath and prepares to perform a song for %w.} {#var mipgag 1};
-	#REGEX {%0} {~%w~sings soulfully} {#var mipgag 1};
+	#REGEX {$msg} {~cracks %w knuckles and gets ready to play for } {#var mipgag 1};
+	#REGEX {$msg} {~ceases his performance.} {#var mipgag 1};
+	#REGEX {$msg} {~takes a deep breath.} {#var mipgag 1};
+	#REGEX {$msg} {~takes a breath.} {#var mipgag 1};
+	#REGEX {$msg} {~pauses for a moment...} {#var mipgag 1};
+	#REGEX {$msg} {~ceases his performance.} {#var mipgag 1};
+	#REGEX {$msg} {~%w~finishes %w performance with a bow.} {#var mipgag 1};
+	#REGEX {$msg} {~%w~takes a deep breath and prepares to perform a song for you.} {#var mipgag 1};
+	#REGEX {$msg} {~Great~cheer fills you, it's almost overwhelming!} {#var mipgag 1};
+	#REGEX {$msg} {~%w~smiles happily.} {#var mipgag 1};
+	#REGEX {$msg} {~%w~takes a deep breath and prepares to perform a song for %w.} {#var mipgag 1};
+	#REGEX {$msg} {~%w~sings soulfully} {#var mipgag 1};
 
 	#NOP Bladesingers;
-	#REGEX {%0} {~Corath~} {#var mipgag 1};
-	#REGEX {%0} {~Amarul~} {#var mipgag 1};
+	#REGEX {$msg} {~Corath~} {#var mipgag 1};
+	#REGEX {$msg} {~Amarul~} {#var mipgag 1};
 
 	#NOP Breed;
-	#REGEX {%0} {looks visibly weaker!} {#var mipgag 1};
-	#REGEX {%0} {looks more vulnerable!} {#var mipgag 1};
+	#REGEX {$msg} {looks visibly weaker!} {#var mipgag 1};
+	#REGEX {$msg} {looks more vulnerable!} {#var mipgag 1};
 
 	#NOP Changelings;
-	#REGEX {%0} {~The~%*'s wounds close rapidly.} {#var mipgag 1};
-	#REGEX {%0} {~The~%* performs a rather incomprehensible action on the corpse.} {#var mipgag 1};
-	#REGEX {%0} {~The~small wolf sighs.} {#var mipgag 1};
+	#REGEX {$msg} {~The~%*'s wounds close rapidly.} {#var mipgag 1};
+	#REGEX {$msg} {~The~%* performs a rather incomprehensible action on the corpse.} {#var mipgag 1};
+	#REGEX {$msg} {~The~small wolf sighs.} {#var mipgag 1};
 
 	#NOP Cove of the Three (Lost Soul);
-	#REGEX {%0} {~~You try to clasp onto the diamond spectacle, but your hands fall right through!} {#var mipgag 1};
-	#REGEX {%0} {~~Bursts of %w colored energy shoot off from the spectacle.} {#var mipgag 1};
-	#REGEX {%0} {~~The diamond-spectacle spins and turns on an unseen axis.} {#var mipgag 1};
-	#REGEX {%0} {~~The diamond-shaped spectacle changes color.} {#var mipgag 1};
+	#REGEX {$msg} {~~You try to clasp onto the diamond spectacle, but your hands fall right through!} {#var mipgag 1};
+	#REGEX {$msg} {~~Bursts of %w colored energy shoot off from the spectacle.} {#var mipgag 1};
+	#REGEX {$msg} {~~The diamond-spectacle spins and turns on an unseen axis.} {#var mipgag 1};
+	#REGEX {$msg} {~~The diamond-shaped spectacle changes color.} {#var mipgag 1};
 
 	#NOP Carina's Observatory;
-	#REGEX {%0} {~~Carina looks up at you as if to say something, but shrugs it off.} {#var mipgag 1};
+	#REGEX {$msg} {~~Carina looks up at you as if to say something, but shrugs it off.} {#var mipgag 1};
 
 	#NOP Duke Nukem;
-	#REGEX {%0} {~~As you land upon the rooftop, you see your ship crash into a building in the} {#var mipgag 1};
-	#REGEX {%0} {~~You break the fan, revealing an exit!} {#var mipgag 1};
-	#REGEX {%0} {~~You see the assault trooper and taunt him, WHO'S YOUR DADDY!!??} {#var mipgag 1};
-	#REGEX {%0} {~~The room shakes.......And a piece of the wall is blown away!} {#var mipgag 1};
+	#REGEX {$msg} {~~As you land upon the rooftop, you see your ship crash into a building in the} {#var mipgag 1};
+	#REGEX {$msg} {~~You break the fan, revealing an exit!} {#var mipgag 1};
+	#REGEX {$msg} {~~You see the assault trooper and taunt him, WHO'S YOUR DADDY!!??} {#var mipgag 1};
+	#REGEX {$msg} {~~The room shakes.......And a piece of the wall is blown away!} {#var mipgag 1};
 
 	#NOP Dundee;
-	#REGEX {%0} {~A~shiver runs through you as you successfully fight off an infection.} {#var mipgag 1};
-	#REGEX {%0} {~Your~head throbs briefly as you successfully fight off an infection.} {#var mipgag 1};
-	#REGEX {%0} {~Your~temperature spikes as you successfully fight off an infection.} {#var mipgag 1};
-	#REGEX {%0} {~Your~palms begin to sweat as you successfully fight off an infection.} {#var mipgag 1};
-	#REGEX {%0} {~Your~neck aches slightly as you successfully fight off an infection.} {#var mipgag 1};
+	#REGEX {$msg} {~A~shiver runs through you as you successfully fight off an infection.} {#var mipgag 1};
+	#REGEX {$msg} {~Your~head throbs briefly as you successfully fight off an infection.} {#var mipgag 1};
+	#REGEX {$msg} {~Your~temperature spikes as you successfully fight off an infection.} {#var mipgag 1};
+	#REGEX {$msg} {~Your~palms begin to sweat as you successfully fight off an infection.} {#var mipgag 1};
+	#REGEX {$msg} {~Your~neck aches slightly as you successfully fight off an infection.} {#var mipgag 1};
 
 	#NOP Hell Cows;
-	#REGEX {%0} {~A~cow falls, but the herd continues on!} {#var mipgag 1};
-	#REGEX {%0} {~The~lonesome cow topples to the ground, the herd finally slain.} {#var mipgag 1};
+	#REGEX {$msg} {~A~cow falls, but the herd continues on!} {#var mipgag 1};
+	#REGEX {$msg} {~The~lonesome cow topples to the ground, the herd finally slain.} {#var mipgag 1};
 
 	#NOP Knights;
-	#REGEX {%0} {~Bela~} {#var mipgag 1};
+	#REGEX {$msg} {~Bela~} {#var mipgag 1};
 
 	#NOP Necromancer;
-	#REGEX {%0} {~The~spirit of the beast leaves your body, slightly weakening you.} {#var mipgag 1};
-	#REGEX {%0} {~%w~appears slightly drained.} {#var mipgag 1};
+	#REGEX {$msg} {~The~spirit of the beast leaves your body, slightly weakening you.} {#var mipgag 1};
+	#REGEX {$msg} {~%w~appears slightly drained.} {#var mipgag 1};
 
 	#NOP Party Divvy;
-	#REGEX {%0} {[PARTY] GOLD divvy called by } {#var mipgag 1};
-	#REGEX {%0} {[PARTY] All gold divvied, total: } {#var mipgag 1};
+	#REGEX {$msg} {[PARTY] GOLD divvy called by } {#var mipgag 1};
+	#REGEX {$msg} {[PARTY] All gold divvied, total: } {#var mipgag 1};
 
 	#NOP Sii;
-	#REGEX {%0} {~Your~malicious attacks fade} {#var mipgag 1};
-	#REGEX {%0} {~The~corpse explodes as a small vicious lizard-like creature bursts forth!} {#var mipgag 1};
+	#REGEX {$msg} {~Your~malicious attacks fade} {#var mipgag 1};
+	#REGEX {$msg} {~The~corpse explodes as a small vicious lizard-like creature bursts forth!} {#var mipgag 1};
 
 	#NOP Tomb of King Alaren;
-	#REGEX {%0} {~With~a mighty heave you shoulder charge into the eastern wall.} {#var mipgag 1};
-	#REGEX {%0} {~~With a slow rumble the wall finally crumbles, filling the room in a cloud of} {#var mipgag 1};
-	#REGEX {%0} {~His~service to his King complete, the guard clatters to the floor, the dark magic} {#var mipgag 1};
-	#REGEX {%0} {~The~skeletal royal guard steps in front of you barring your progress.} {#var mipgag 1};
-	#REGEX {%0} {~Harakir~slumps to the floor, defeated, perhaps now his soul will find} {#var mipgag 1};
-	#REGEX {%0} {~With~a few swings of your } {#var mipgag 1};
-	#REGEX {%0} {~With~a mighty heave you push the [stone|golden] lid sliding it back from the coffin} {#var mipgag 1};
-	#REGEX {%0} {~Turning~to leave you hear Mircarla's sultry voice calling you back} {#var mipgag 1};
-	#REGEX {%0} {~Caught~unaware by her turn of pace as you attack, you} {#var mipgag 1};
-	#REGEX {%0} {~Before~your very eyes you stare in amazement as Mircarla} {#var mipgag 1};
-	#REGEX {%0} {~Her~meal completed, she clambers off you licking her now ruby red lips} {#var mipgag 1};
-	#REGEX {%0} {~Mircarla~sighs, the last of her energy expended as she slumps to the floor} {#var mipgag 1};
-	#REGEX {%0} {~Sumaren~crumples to the ground, destroyed, perhaps at last his soul will find} {#var mipgag 1};
-	#REGEX {%0} {~Someone~has already pushed the lid open, there's no need to push it again.} {#var mipgag 1};
-	#REGEX {%0} {~Straining~with all your might you give the ring a mighty heave, at first} {#var mipgag 1};
-	#REGEX {%0} {~Reaching~out, you give the gates a firm push. With an echoing screech the} {#var mipgag 1};
-	#REGEX {%0} {~Alaren~begins to slowly lose cohesion, glowing ever brighter until, suddenly} {#var mipgag 1};
-	#REGEX {%0} {~The~skeletal guard steps in front of you barring your progress.} {#var mipgag 1};
+	#REGEX {$msg} {~With~a mighty heave you shoulder charge into the eastern wall.} {#var mipgag 1};
+	#REGEX {$msg} {~~With a slow rumble the wall finally crumbles, filling the room in a cloud of} {#var mipgag 1};
+	#REGEX {$msg} {~His~service to his King complete, the guard clatters to the floor, the dark magic} {#var mipgag 1};
+	#REGEX {$msg} {~The~skeletal royal guard steps in front of you barring your progress.} {#var mipgag 1};
+	#REGEX {$msg} {~Harakir~slumps to the floor, defeated, perhaps now his soul will find} {#var mipgag 1};
+	#REGEX {$msg} {~With~a few swings of your } {#var mipgag 1};
+	#REGEX {$msg} {~With~a mighty heave you push the [stone|golden] lid sliding it back from the coffin} {#var mipgag 1};
+	#REGEX {$msg} {~Turning~to leave you hear Mircarla's sultry voice calling you back} {#var mipgag 1};
+	#REGEX {$msg} {~Caught~unaware by her turn of pace as you attack, you} {#var mipgag 1};
+	#REGEX {$msg} {~Before~your very eyes you stare in amazement as Mircarla} {#var mipgag 1};
+	#REGEX {$msg} {~Her~meal completed, she clambers off you licking her now ruby red lips} {#var mipgag 1};
+	#REGEX {$msg} {~Mircarla~sighs, the last of her energy expended as she slumps to the floor} {#var mipgag 1};
+	#REGEX {$msg} {~Sumaren~crumples to the ground, destroyed, perhaps at last his soul will find} {#var mipgag 1};
+	#REGEX {$msg} {~Someone~has already pushed the lid open, there's no need to push it again.} {#var mipgag 1};
+	#REGEX {$msg} {~Straining~with all your might you give the ring a mighty heave, at first} {#var mipgag 1};
+	#REGEX {$msg} {~Reaching~out, you give the gates a firm push. With an echoing screech the} {#var mipgag 1};
+	#REGEX {$msg} {~Alaren~begins to slowly lose cohesion, glowing ever brighter until, suddenly} {#var mipgag 1};
+	#REGEX {$msg} {~The~skeletal guard steps in front of you barring your progress.} {#var mipgag 1};
 
 	#NOP Wrapping with no corpse in room;
-	#REGEX {%0} {~%w~wraps %w arms around %w.} {#var mipgag 1};
+	#REGEX {$msg} {~%w~wraps %w arms around %w.} {#var mipgag 1};
 
 	#NOP Zelligar's Headband;
-	#REGEX {%0} { stumbles in confusion as the headband hypnotizes } {#var mipgag 1};
+	#REGEX {$msg} { stumbles in confusion as the headband hypnotizes } {#var mipgag 1};
 
-	#IF {$mipgag == 0} {.mipProcessBAB %0}
+	#IF {$mipgag == 0} {.mipProcessBAB $msg}
 }
 
 #var chat[max] 100

--- a/3k/mip.tin
+++ b/3k/mip.tin
@@ -752,7 +752,7 @@
 	#NOP Zelligar's Headband;
 	#REGEX {$msg} { stumbles in confusion as the headband hypnotizes } {#var mipgag 1};
 
-	#IF {$mipgag == 0} {.mipProcessBAB $msg}
+	#IF {$mipgag == 0} {.mipProcessBAB %0}
 }
 
 #var chat[max] 100


### PR DESCRIPTION
current tt++ does not properly handle ansi codes in the string string (likely the common issue with string lengths).  By stripping these before evaluating, we prevent the memory error and crash that has been causing people to disconnect from large ansi msgs.